### PR TITLE
fix(pipesock): reject over-long unix socket paths by name

### DIFF
--- a/pipesock/pathlimit_other.go
+++ b/pipesock/pathlimit_other.go
@@ -1,0 +1,7 @@
+//go:build !unix && !windows
+
+package pipesock
+
+// maxPipePathLen is the shortest sun_path limit among the unix platforms,
+// used where the platform does not expose sun_path at all.
+var maxPipePathLen = 103

--- a/pipesock/pathlimit_test.go
+++ b/pipesock/pathlimit_test.go
@@ -1,0 +1,84 @@
+//go:build !windows
+
+package pipesock
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// longPipeRoot builds a directory whose path exceeds any sun_path limit both
+// as an absolute path and as a path relative to the working directory.
+func longPipeRoot(t *testing.T) string {
+	t.Helper()
+	base, err := os.MkdirTemp("/tmp", "ps")
+	if err != nil {
+		t.Fatalf("make temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(base) })
+	root := base
+	for range 8 {
+		root = filepath.Join(root, strings.Repeat("d", 24))
+	}
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("make nested dir: %v", err)
+	}
+	return root
+}
+
+func TestBuildPipeListenerRejectsOverLongPath(t *testing.T) {
+	root := longPipeRoot(t)
+	listener, err := BuildPipeListener(newTestLogger(), root, "startup")
+	if err == nil {
+		_ = listener.Close()
+		t.Fatal("expected an error for a socket path longer than the platform limit")
+	}
+	if !strings.Contains(err.Error(), "binds at most") {
+		t.Fatalf("error does not name the platform limit: %v", err)
+	}
+	if !strings.Contains(err.Error(), root) {
+		t.Fatalf("error does not name the offending path: %v", err)
+	}
+}
+
+func TestDialPipeListenerRejectsOverLongPath(t *testing.T) {
+	root := longPipeRoot(t)
+	conn, err := DialPipeListener(context.Background(), newTestLogger(), root, "startup")
+	if err == nil {
+		_ = conn.Close()
+		t.Fatal("expected an error for a socket path longer than the platform limit")
+	}
+	if !strings.Contains(err.Error(), "binds at most") {
+		t.Fatalf("error does not name the platform limit: %v", err)
+	}
+}
+
+// TestBuildPipeListenerUsesRelativePathUnderTheLimit covers the case the
+// shortening exists for: an absolute path the platform refuses, reachable by a
+// relative path it accepts.
+func TestBuildPipeListenerUsesRelativePathUnderTheLimit(t *testing.T) {
+	root := longPipeRoot(t)
+	if len(root) <= maxPipePathLen {
+		t.Fatalf("test root is not long enough to exercise the shortening: %d", len(root))
+	}
+	t.Chdir(filepath.Dir(root))
+
+	listener, err := BuildPipeListener(newTestLogger(), root, "startup")
+	if err != nil {
+		t.Fatalf("listen through the relative path: %v", err)
+	}
+	defer listener.Close()
+
+	if got := listener.Addr().String(); filepath.IsAbs(got) {
+		t.Fatalf("listener bound the absolute path rather than the shorter relative one: %s", got)
+	}
+}
+
+func TestMaxPipePathLenMatchesPlatform(t *testing.T) {
+	if maxPipePathLen < 90 || maxPipePathLen > 120 {
+		t.Fatalf("sun_path limit outside the range every unix platform uses: %d", maxPipePathLen)
+	}
+}

--- a/pipesock/pathlimit_unix.go
+++ b/pipesock/pathlimit_unix.go
@@ -1,0 +1,10 @@
+//go:build unix
+
+package pipesock
+
+import "syscall"
+
+// maxPipePathLen is the longest unix socket path this platform binds.
+// sun_path is a fixed-size field and the kernel requires a terminating zero
+// byte inside it, so one byte fewer than the field is usable.
+var maxPipePathLen = len(syscall.RawSockaddrUnix{}.Path) - 1

--- a/pipesock/pipesock.go
+++ b/pipesock/pipesock.go
@@ -12,19 +12,12 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// BuildPipeListener builds the pipe listener.
-// The rootDir is used for unix sockets if this is a linux system.
-// The pipeUuid is used for the socket path OR the Windows Pipe Name.
-// The pipeUuid should be unique to the local device and pipe.
-func BuildPipeListener(le *logrus.Entry, rootDir, pipeUuid string) (net.Listener, error) {
+// resolvePipePath builds the unix socket path for a pipe.
+// The kernel bounds sun_path, so an over-long path is rejected here by name
+// rather than at bind time as an opaque invalid argument.
+func resolvePipePath(le *logrus.Entry, rootDir, pipeUuid string) (string, error) {
 	// Create absolute path for the socket
 	absolutePipePath := filepath.Join(rootDir, ".pipe-"+pipeUuid)
-
-	// Ensure the parent directory exists
-	pipeDir := filepath.Dir(absolutePipePath)
-	if err := os.MkdirAll(pipeDir, 0o755); err != nil {
-		return nil, errors.Wrap(err, "create pipe directory")
-	}
 
 	// Get current working directory
 	cwd, err := os.Getwd()
@@ -35,13 +28,38 @@ func BuildPipeListener(le *logrus.Entry, rootDir, pipeUuid string) (net.Listener
 	}
 
 	// Get relative path from current working directory if possible
-	// Use whichever is shorter (Unix socket paths are limited to ~104 chars)
+	// Use whichever is shorter, since sun_path is small.
 	pipePath := absolutePipePath
 	if cwd != "" {
 		relPath, err := filepath.Rel(cwd, absolutePipePath)
-		if err == nil && len(relPath) < len(absolutePipePath) {
+		if err == nil && len(relPath) < len(pipePath) {
 			pipePath = relPath
 		}
+	}
+
+	if len(pipePath) > maxPipePathLen {
+		return "", errors.Errorf(
+			"unix socket path is %d bytes and this platform binds at most %d: %s",
+			len(pipePath), maxPipePathLen, pipePath,
+		)
+	}
+	return pipePath, nil
+}
+
+// BuildPipeListener builds the pipe listener.
+// The rootDir is used for unix sockets if this is a linux system.
+// The pipeUuid is used for the socket path OR the Windows Pipe Name.
+// The pipeUuid should be unique to the local device and pipe.
+func BuildPipeListener(le *logrus.Entry, rootDir, pipeUuid string) (net.Listener, error) {
+	// Ensure the parent directory exists
+	pipeDir := filepath.Dir(filepath.Join(rootDir, ".pipe-"+pipeUuid))
+	if err := os.MkdirAll(pipeDir, 0o755); err != nil {
+		return nil, errors.Wrap(err, "create pipe directory")
+	}
+
+	pipePath, err := resolvePipePath(le, rootDir, pipeUuid)
+	if err != nil {
+		return nil, err
 	}
 
 	// remove old pipe file, if exists
@@ -61,32 +79,16 @@ func BuildPipeListener(le *logrus.Entry, rootDir, pipeUuid string) (net.Listener
 
 // DialPipeListener connects to the pipe listener in the directory.
 func DialPipeListener(ctx context.Context, le *logrus.Entry, rootDir, pipeUuid string) (net.Conn, error) {
-	// Create absolute path for the socket
-	absolutePipePath := filepath.Join(rootDir, ".pipe-"+pipeUuid)
-
-	// Get current working directory
-	cwd, err := os.Getwd()
+	pipePath, err := resolvePipePath(le, rootDir, pipeUuid)
 	if err != nil {
-		// If we can't get CWD (e.g., it was deleted), use absolute path
-		le.WithError(err).Debug("could not get cwd, using absolute pipe path")
-		cwd = ""
-	}
-
-	// Get relative path from current working directory if possible
-	// Use whichever is shorter (Unix socket paths are limited to ~104 chars)
-	pipePath := absolutePipePath
-	if cwd != "" {
-		relPath, err := filepath.Rel(cwd, absolutePipePath)
-		if err == nil && len(relPath) < len(absolutePipePath) {
-			pipePath = relPath
-		}
+		return nil, err
 	}
 
 	addr := &net.UnixAddr{
 		Net:  "unix",
 		Name: pipePath,
 	}
-	le.Debugf("connecting to unix socket: %s (cwd: %s)", addr.String(), cwd)
+	le.Debugf("connecting to unix socket: %s", addr.String())
 	dialer := net.Dialer{}
 	return dialer.DialContext(ctx, "unix", addr.String())
 }


### PR DESCRIPTION
sun_path is a fixed-size field, 104 bytes on Darwin and 108 on Linux, so a socket path longer than the platform allows is refused by the kernel with EINVAL. That surfaces to the caller as "bind: invalid argument", which names neither the limit nor the path that exceeded it.

BuildPipeListener and DialPipeListener both knew about the limit already: each tried a relative path when it was shorter than the absolute one, with a comment citing the 104-byte bound, and then handed whatever it had to the kernel unchecked. Neither enforced the bound it was working around.

This resolves the path once, in one place both entry points share, and returns an error naming the byte count, the platform limit, and the path when it does not fit. The limit is read from sun_path itself on unix so each platform gets its own value, with a fallback to the smallest limit in use where the platform does not expose the field.

Found through a Spacewave daemon startup test that is unrunnable on macOS because Go's t.TempDir() builds a path from the test name and the result exceeds 104 bytes. This repository's own pipesock tests already carry a shortTempDir helper for the same reason.