### PR TITLE
fix(pipesock): reject over-long Unix socket paths

### DIFF
--- a/pipesock/pipesock.go
+++ b/pipesock/pipesock.go
@@ -20,12 +20,6 @@ func BuildPipeListener(le *logrus.Entry, rootDir, pipeUuid string) (net.Listener
 	// Create absolute path for the socket
 	absolutePipePath := filepath.Join(rootDir, ".pipe-"+pipeUuid)
 
-	// Ensure the parent directory exists
-	pipeDir := filepath.Dir(absolutePipePath)
-	if err := os.MkdirAll(pipeDir, 0o755); err != nil {
-		return nil, errors.Wrap(err, "create pipe directory")
-	}
-
 	// Get current working directory
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -42,6 +36,15 @@ func BuildPipeListener(le *logrus.Entry, rootDir, pipeUuid string) (net.Listener
 		if err == nil && len(relPath) < len(absolutePipePath) {
 			pipePath = relPath
 		}
+	}
+	if err := validateUnixSocketPath(pipePath); err != nil {
+		return nil, err
+	}
+
+	// Ensure the parent directory exists
+	pipeDir := filepath.Dir(absolutePipePath)
+	if err := os.MkdirAll(pipeDir, 0o755); err != nil {
+		return nil, errors.Wrap(err, "create pipe directory")
 	}
 
 	// remove old pipe file, if exists

--- a/pipesock/pipesock_test.go
+++ b/pipesock/pipesock_test.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !js && !wasip1 && !plan9
 
 package pipesock
 
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -128,6 +130,36 @@ func TestBuildPipeListener(t *testing.T) {
 			t.Error("pipe-b not found")
 		}
 	})
+}
+
+func TestBuildPipeListenerRejectsOverlongUnixSocketPath(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootDir := filepath.Join(cwd, strings.Repeat("d", maxUnixSocketPathLength))
+	absolutePipePath := filepath.Join(rootDir, ".pipe-overlong")
+	pipePath := absolutePipePath
+	if relPath, err := filepath.Rel(cwd, absolutePipePath); err == nil && len(relPath) < len(absolutePipePath) {
+		pipePath = relPath
+	}
+
+	_, err = BuildPipeListener(newTestLogger(), rootDir, "overlong")
+	if err == nil {
+		t.Fatal("BuildPipeListener accepted an over-long Unix socket path")
+	}
+	for _, want := range []string{
+		strconv.Itoa(maxUnixSocketPathLength),
+		strconv.Itoa(len(pipePath)),
+		pipePath,
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not name %q", err, want)
+		}
+	}
+	if strings.Contains(err.Error(), "bind: invalid argument") {
+		t.Errorf("BuildPipeListener deferred rejection to bind: %v", err)
+	}
 }
 
 func TestDialPipeListener(t *testing.T) {

--- a/pipesock/unix-path-limit-js.go
+++ b/pipesock/unix-path-limit-js.go
@@ -1,0 +1,7 @@
+//go:build js || wasip1 || plan9
+
+package pipesock
+
+func validateUnixSocketPath(string) error {
+	return nil
+}

--- a/pipesock/unix-path-limit.go
+++ b/pipesock/unix-path-limit.go
@@ -1,0 +1,22 @@
+//go:build !windows && !js && !wasip1 && !plan9
+
+package pipesock
+
+import (
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+const maxUnixSocketPathLength = len(unix.RawSockaddrUnix{}.Path)
+
+func validateUnixSocketPath(path string) error {
+	if len(path) > maxUnixSocketPathLength {
+		return errors.Errorf(
+			"unix socket path exceeds %d-byte limit: path is %d bytes: %s",
+			maxUnixSocketPathLength,
+			len(path),
+			path,
+		)
+	}
+	return nil
+}


### PR DESCRIPTION
Validate the selected Unix socket path before creating directories or asking the kernel to bind it. Derive the platform limit from the Unix sockaddr definition so callers receive the byte limit, actual length, and path instead of an opaque bind error. The focused regression test fails with bind: invalid argument when the validation is disabled and passes with the owner-side check.