### PR TITLE
feat(routine): separate state and restart comparison

### DIFF
--- a/routine/state.go
+++ b/routine/state.go
@@ -14,6 +14,9 @@ type StateRoutineContainer[T comparable] struct {
 	// compare compares if the two states are equivalent
 	// if nil restarts the routine every time SetState is called
 	compare func(t1, t2 T) bool
+	// restartCompare compares if two changed states are equivalent to the routine.
+	// If nil, every state change restarts the routine.
+	restartCompare func(t1, t2 T) bool
 	// stateRoutine contains the state routine function
 	stateRoutine StateRoutine[T]
 	// s contains the current state
@@ -37,6 +40,24 @@ func NewStateRoutineContainer[T comparable](compare func(t1, t2 T) bool, opts ..
 	return &StateRoutineContainer[T]{
 		rc:      NewRoutineContainer(opts...),
 		compare: compare,
+	}
+}
+
+// NewStateRoutineContainerWithRestartCompare constructs a StateRoutineContainer
+// with separate state and routine equivalence comparisons.
+//
+// compare controls whether SetState stores and broadcasts a state change.
+// restartCompare controls whether a stored state change restarts the routine.
+// A nil restartCompare preserves the default of restarting on every state change.
+func NewStateRoutineContainerWithRestartCompare[T comparable](
+	compare,
+	restartCompare func(t1, t2 T) bool,
+	opts ...Option,
+) *StateRoutineContainer[T] {
+	return &StateRoutineContainer[T]{
+		rc:             NewRoutineContainer(opts...),
+		compare:        compare,
+		restartCompare: restartCompare,
 	}
 }
 
@@ -84,10 +105,13 @@ func (s *StateRoutineContainer[T]) GetState() T {
 	return state
 }
 
-// SetState sets the state in the StateRoutineContainer.
+// SetState stores state and reconciles the running routine.
 //
-// Returns if the state changed and if the routine is running.
-// If reset=true the existing routine was canceled or restarted.
+// waitReturn is non-nil when reset is true and closes after the previous
+// routine exits. changed reports whether state was stored and broadcast.
+// reset reports whether an existing routine was canceled or replaced. When
+// changed is true, running reports whether a routine is running after the
+// operation. When changed is false, the other return values are zero values.
 func (s *StateRoutineContainer[T]) SetState(state T) (waitReturn <-chan struct{}, changed, reset, running bool) {
 	s.rc.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
 		waitReturn, changed, reset, running = s.setStateLocked(state, broadcast)
@@ -97,14 +121,19 @@ func (s *StateRoutineContainer[T]) SetState(state T) (waitReturn <-chan struct{}
 
 // setStateLocked compares and updates the state when mtx is locked.
 func (s *StateRoutineContainer[T]) setStateLocked(state T, broadcast func()) (waitReturn <-chan struct{}, changed, reset, running bool) {
+	previousState := s.s
 	if s.compare == nil {
 		changed = true
 	} else {
-		changed = !s.compare(s.s, state)
+		changed = !s.compare(previousState, state)
 	}
 	if changed {
 		s.s = state
-		waitReturn, reset, running = s.updateStateRoutineLocked(broadcast)
+		if s.restartCompare == nil || !s.restartCompare(previousState, state) {
+			waitReturn, reset, running = s.updateStateRoutineLocked(broadcast)
+		} else {
+			running = s.rc.getRunningLocked()
+		}
 		broadcast()
 	}
 	return

--- a/routine/state_test.go
+++ b/routine/state_test.go
@@ -156,3 +156,133 @@ func TestStateRoutineContainer(t *testing.T) {
 		t.FailNow()
 	}
 }
+
+func TestStateRoutineContainerRestartCompare(t *testing.T) {
+	started := make(chan int, 2)
+	stopped := make(chan int, 2)
+	stateRoutine := func(ctx context.Context, state int) error {
+		started <- state
+		<-ctx.Done()
+		stopped <- state
+		return ctx.Err()
+	}
+	stateEqual := func(a, b int) bool { return a == b }
+	routineEqual := func(a, b int) bool { return a/10 == b/10 }
+	optionApplied := false
+	container := NewStateRoutineContainerWithRestartCompare(
+		stateEqual,
+		routineEqual,
+		newOption(func(*RoutineContainer) { optionApplied = true }),
+	)
+	if !optionApplied {
+		t.Fatal("constructor option was not applied")
+	}
+	container.SetStateRoutine(stateRoutine)
+	runCtx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	container.SetContext(runCtx, false)
+
+	if _, changed, reset, running := container.SetState(11); !changed || reset || !running {
+		t.Fatalf("initial state returned changed=%t reset=%t running=%t", changed, reset, running)
+	}
+	requireStateRoutineValue(t, started, 11, "initial routine start")
+
+	noRestartBroadcast := stateRoutineBroadcast(container)
+	waitReturn, changed, reset, running := container.SetState(12)
+	if !changed || reset || !running || waitReturn != nil {
+		t.Fatalf("equivalent routine state returned wait=%v changed=%t reset=%t running=%t", waitReturn != nil, changed, reset, running)
+	}
+	if got := container.GetState(); got != 12 {
+		t.Fatalf("stored state = %d, want 12", got)
+	}
+	requireStateRoutineBroadcast(t, noRestartBroadcast, "equivalent routine state")
+
+	unchangedBroadcast := stateRoutineBroadcast(container)
+	waitReturn, changed, reset, running = container.SetState(12)
+	if changed || reset || running || waitReturn != nil {
+		t.Fatalf("unchanged state returned wait=%v changed=%t reset=%t running=%t", waitReturn != nil, changed, reset, running)
+	}
+	requireStateRoutineNoBroadcast(t, unchangedBroadcast, "unchanged state")
+
+	restartBroadcast := stateRoutineBroadcast(container)
+	waitReturn, changed, reset, running = container.SetState(21)
+	if !changed || !reset || !running || waitReturn == nil {
+		t.Fatalf("restart state returned wait=%v changed=%t reset=%t running=%t", waitReturn != nil, changed, reset, running)
+	}
+	requireStateRoutineBroadcast(t, restartBroadcast, "restart state")
+	requireStateRoutineValue(t, stopped, 11, "restarted routine stop")
+	requireStateRoutineValue(t, started, 21, "restarted routine start")
+
+	cancel()
+	requireStateRoutineValue(t, stopped, 21, "cleanup routine stop")
+	container.ClearContext()
+}
+
+func TestStateRoutineContainerNilRestartComparePreservesRestart(t *testing.T) {
+	started := make(chan int, 2)
+	stopped := make(chan int, 2)
+	container := NewStateRoutineContainerWithRestartCompare(
+		func(a, b int) bool { return a == b },
+		nil,
+	)
+	container.SetStateRoutine(func(ctx context.Context, state int) error {
+		started <- state
+		<-ctx.Done()
+		stopped <- state
+		return ctx.Err()
+	})
+	runCtx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	container.SetContext(runCtx, false)
+	container.SetState(1)
+	requireStateRoutineValue(t, started, 1, "initial routine start")
+
+	waitReturn, changed, reset, running := container.SetState(2)
+	if !changed || !reset || !running || waitReturn == nil {
+		t.Fatalf("nil restart comparator returned wait=%v changed=%t reset=%t running=%t", waitReturn != nil, changed, reset, running)
+	}
+	requireStateRoutineValue(t, stopped, 1, "restarted routine stop")
+	requireStateRoutineValue(t, started, 2, "restarted routine start")
+
+	cancel()
+	requireStateRoutineValue(t, stopped, 2, "cleanup routine stop")
+	container.ClearContext()
+}
+
+func stateRoutineBroadcast[T comparable](container *StateRoutineContainer[T]) <-chan struct{} {
+	var wait <-chan struct{}
+	container.rc.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
+		wait = getWaitCh()
+	})
+	return wait
+}
+
+func requireStateRoutineBroadcast(t *testing.T, wait <-chan struct{}, event string) {
+	t.Helper()
+	select {
+	case <-wait:
+	default:
+		t.Fatalf("%s did not broadcast", event)
+	}
+}
+
+func requireStateRoutineNoBroadcast(t *testing.T, wait <-chan struct{}, event string) {
+	t.Helper()
+	select {
+	case <-wait:
+		t.Fatalf("%s broadcast", event)
+	default:
+	}
+}
+
+func requireStateRoutineValue(t *testing.T, values <-chan int, want int, event string) {
+	t.Helper()
+	select {
+	case got := <-values:
+		if got != want {
+			t.Fatalf("%s value = %d, want %d", event, got, want)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("%s did not occur", event)
+	}
+}


### PR DESCRIPTION
A state routine container used one comparison to answer two questions: whether the stored state had changed, and whether the running routine had to be restarted. A caller whose state carries a field the routine does not depend on could not record a change to that field without tearing down and restarting the routine.

This takes an optional second comparison that reports whether a stored change is equivalent to the running routine. When it reports equivalence the container stores the new state and broadcasts without touching the routine. Callers that omit it keep the existing behavior of restarting on every change.