### PR TITLE
fix(autobun): extract entries under the decompression cap

### DIFF
--- a/autobun/autobun.go
+++ b/autobun/autobun.go
@@ -191,10 +191,11 @@ func extractBunFromZip(zipPath, destDir string) error {
 
 		// Cap at 500MB to prevent decompression bombs.
 		const maxCopySize int64 = 500 * 1024 * 1024
-		_, err = io.CopyN(outFile, rc, maxCopySize)
+		err = copyCapped(outFile, rc, maxCopySize)
 		rc.Close()
 		outFile.Close()
 		if err != nil {
+			os.Remove(destPath)
 			return err
 		}
 
@@ -202,6 +203,21 @@ func extractBunFromZip(zipPath, destDir string) error {
 	}
 
 	return errors.New("bun binary not found in zip")
+}
+
+// copyCapped copies src to dst, rejecting sources of limit or more bytes.
+// A rejected copy returns an error after writing limit bytes to dst; the
+// caller discards the partial output.
+func copyCapped(dst io.Writer, src io.Reader, limit int64) error {
+	n, err := io.CopyN(dst, src, limit)
+	if err == io.EOF {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	// n == limit with no error: src holds at least limit bytes.
+	return errors.Errorf("entry exceeds size limit: %d bytes", n)
 }
 
 // EnsureBun ensures bun is available, downloading it if necessary.

--- a/autobun/autobun_test.go
+++ b/autobun/autobun_test.go
@@ -1,0 +1,72 @@
+package autobun
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// buildBunZip writes a zip containing a bun binary entry with the given data.
+func buildBunZip(t *testing.T, data []byte) string {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, err := zw.Create("bun-dist/" + GetBunBinaryName())
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if _, err := w.Write(data); err != nil {
+		t.Fatal(err.Error())
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err.Error())
+	}
+	zipPath := filepath.Join(t.TempDir(), "bun.zip")
+	if err := os.WriteFile(zipPath, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err.Error())
+	}
+	return zipPath
+}
+
+// TestExtractBunFromZip checks a normal-sized entry extracts successfully.
+func TestExtractBunFromZip(t *testing.T) {
+	data := []byte("#!/bin/sh\necho bun\n")
+	zipPath := buildBunZip(t, data)
+	destDir := t.TempDir()
+	if err := extractBunFromZip(zipPath, destDir); err != nil {
+		t.Fatal(err.Error())
+	}
+	out, err := os.ReadFile(filepath.Join(destDir, GetBunBinaryName()))
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if !bytes.Equal(out, data) {
+		t.Fatalf("extracted data mismatch: %q", out)
+	}
+}
+
+// TestCopyCappedBoundary checks both sides of the extraction size cap.
+func TestCopyCappedBoundary(t *testing.T) {
+	const limit = 8
+
+	var under bytes.Buffer
+	if err := copyCapped(&under, strings.NewReader("1234567"), limit); err != nil {
+		t.Fatal(err.Error())
+	}
+	if under.String() != "1234567" {
+		t.Fatalf("under-cap copy mismatch: %q", under.String())
+	}
+
+	var at bytes.Buffer
+	if err := copyCapped(&at, strings.NewReader("12345678"), limit); err == nil {
+		t.Fatal("expected error for source at the cap")
+	}
+
+	var over bytes.Buffer
+	if err := copyCapped(&over, strings.NewReader("123456789"), limit); err == nil {
+		t.Fatal("expected error for source over the cap")
+	}
+}


### PR DESCRIPTION
io.CopyN returns io.EOF when the source holds fewer than the requested byte count, which is the normal case for every bun archive under the 500MB decompression cap, so extractBunFromZip failed every ordinary extraction. An entry of 500MB or more was instead truncated at the cap and reported as success, the opposite of the guard's intent, and the truncated binary would satisfy the os.Stat download check on the next call.

The copy now goes through copyCapped, which treats io.EOF as a complete copy and rejects sources at or over the limit with an error, and the partial output file is removed on failure. Regression tests cover normal extraction through a real zip and both sides of the cap boundary at a small test limit.