### PR TITLE
fix(pipesock): reject over-long unix socket paths in buildPipeName

### DIFF
--- a/pipesock/pipesock.test.ts
+++ b/pipesock/pipesock.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import path from 'path'
+import { buildPipeName } from './pipesock.js'
+
+const itUnix = it.skipIf(process.platform === 'win32')
+
+describe('buildPipeName', () => {
+  itUnix('builds a socket path under the platform limit', () => {
+    const pipePath = buildPipeName('/tmp', 'startup')
+    expect(path.basename(pipePath)).toBe('.pipe-startup')
+  })
+
+  itUnix('rejects an over-long unix socket path by name', () => {
+    // Exceeds every sun_path limit both as an absolute path and as a path
+    // relative to the working directory, mirroring pathlimit_test.go.
+    let root = '/tmp'
+    for (let i = 0; i < 8; i++) {
+      root = path.join(root, 'd'.repeat(24))
+    }
+    expect(() => buildPipeName(root, 'startup')).toThrowError(
+      /unix socket path is \d+ bytes and this platform binds at most \d+: .*\.pipe-startup/,
+    )
+  })
+})

--- a/pipesock/pipesock.ts
+++ b/pipesock/pipesock.ts
@@ -8,6 +8,13 @@ import {
   combineUint8ArrayListTransform,
 } from 'starpc'
 
+// maxPipePathLen is the longest unix socket path this platform binds.
+// sun_path is a fixed-size field and the kernel requires a terminating zero
+// byte inside it, so one byte fewer than the field is usable. Linux sizes
+// sun_path at 108 bytes; darwin and the BSDs use 104, which is also the
+// shortest limit among the unix platforms and covers the rest.
+const maxPipePathLen = process.platform === 'linux' ? 107 : 103
+
 /**
  * Builds a pipe name for IPC communication
  * @param rootDir - The root directory where the pipe will be created (used for unix sockets)
@@ -17,22 +24,31 @@ import {
 export function buildPipeName(rootDir: string, pipeUuid: string): string {
   if (process.platform === 'win32') {
     return `\\\\.\\pipe\\aptre\\${pipeUuid}`
-  } else {
-    // Create absolute path for the socket
-    const absolutePath = path.join(rootDir, `.pipe-${pipeUuid}`)
-    try {
-      // Get relative path from current working directory if possible
-      // Use whichever is shorter (Unix socket paths are limited to ~104 chars)
-      const relPath = path.relative(process.cwd(), absolutePath)
-      if (relPath.length < absolutePath.length) {
-        return relPath
-      }
-      return absolutePath
-    } catch {
-      // If we can't get CWD (e.g., it was deleted), use absolute path
-      return absolutePath
-    }
   }
+
+  // Create absolute path for the socket
+  const absolutePath = path.join(rootDir, `.pipe-${pipeUuid}`)
+  let pipePath = absolutePath
+  try {
+    // Get relative path from current working directory if possible
+    // Use whichever is shorter, since sun_path is small.
+    const relPath = path.relative(process.cwd(), absolutePath)
+    if (relPath.length < absolutePath.length) {
+      pipePath = relPath
+    }
+  } catch {
+    // If we can't get CWD (e.g., it was deleted), use the absolute path
+  }
+
+  // The kernel bounds sun_path, so an over-long path is rejected here by
+  // name rather than at bind time as an opaque invalid argument.
+  const pathLen = Buffer.byteLength(pipePath)
+  if (pathLen > maxPipePathLen) {
+    throw new Error(
+      `unix socket path is ${pathLen} bytes and this platform binds at most ${maxPipePathLen}: ${pipePath}`,
+    )
+  }
+  return pipePath
 }
 
 /**


### PR DESCRIPTION
852d339 taught the Go side to reject a unix socket path longer than the platform sun_path limit by name instead of failing opaquely at bind time with EINVAL. The TypeScript client side kept returning the over-long path unchecked, so Node consumers still hit the opaque bind failure.

This ports the same guard to buildPipeName: pick the shorter of the absolute and relative path as before, then throw when its byte length exceeds the platform limit, naming the length, the limit, and the offending path in the error. Linux binds 107 bytes of sun_path; darwin, the BSDs, and the fallback bind 103, matching pathlimit_unix.go and pathlimit_other.go. Windows named pipes take no length check. A vitest regression covers the rejection and the normal path. Exported names and signatures are unchanged.