### PR TITLE
test(routine): wait for restarted failure

### DIFF
--- a/routine/routine_test.go
+++ b/routine/routine_test.go
@@ -164,15 +164,13 @@ func TestRoutineContainer(t *testing.T) {
 	// this time, tell the routine to fail
 	expectedErr := errors.New("expected error for testing")
 	exitWithErr.Store(&expectedErr)
-	startWaitExited()
-	k.RestartRoutine()
-
-	<-time.After(time.Millisecond * 50)
-	errPtr := waitExitedReturned.Load()
-	if errPtr == nil {
-		t.FailNow()
-	} else if (*errPtr) != expectedErr {
-		t.FailNow()
+	if !k.RestartRoutine() {
+		t.Fatal("expected routine restart")
+	}
+	waitCtx, cancelWait := context.WithTimeout(ctx, time.Second)
+	defer cancelWait()
+	if err := k.WaitExited(waitCtx, false, nil); err != expectedErr {
+		t.Fatalf("expected restarted routine to return %v, got %v", expectedErr, err)
 	}
 }
 


### PR DESCRIPTION
The routine container test started WaitExited before restarting the routine. Under CI scheduling, that waiter could observe the preceding successful exit and return nil before the failing restart began.

Restart first, assert that the restart occurred, then wait synchronously for that run and compare its error. This removes the stale-success race and the final sleep used as synchronization.